### PR TITLE
removing second link

### DIFF
--- a/ccdb/api.md
+++ b/ccdb/api.md
@@ -6,5 +6,4 @@ nav: api-docs
 
 The API documentation can be viewed <a href="api/index.html">full screen here</a>.
 <iframe width="100%" height="2000px" src="api/index.html"></iframe>
-The API documentation can be viewed <a href="api/index.html">full screen here</a>.
 <body id="api-docs"></body>


### PR DESCRIPTION
Attempt to see if a different branch name kicks off the gh-pages build process, as well as removing a second, deprecated link.